### PR TITLE
Bug in what is expected from function to be returned - assuming the i…

### DIFF
--- a/W7500P_FW/Libraries/W7500x_stdPeriph_Driver/inc/W7500x_gpio.h
+++ b/W7500P_FW/Libraries/W7500x_stdPeriph_Driver/inc/W7500x_gpio.h
@@ -160,7 +160,7 @@ void GPIO_DeInit(GPIO_TypeDef* GPIOx);
 void GPIO_Init(GPIO_TypeDef* GPIOx, GPIO_InitTypeDef* GPIO_InitStruct);
 void GPIO_StructInit(GPIO_InitTypeDef* GPIO_InitStruct);
 uint8_t GPIO_ReadInputDataBit(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
-uint8_t GPIO_ReadInputData(GPIO_TypeDef* GPIOx);
+uint16_t GPIO_ReadInputData(GPIO_TypeDef* GPIOx);
 uint8_t GPIO_ReadOutputDataBit(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
 uint16_t GPIO_ReadOutputData(GPIO_TypeDef* GPIOx);
 void GPIO_SetBits(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);


### PR DESCRIPTION
…mplementation is correct as it casts uint16_t as return data type.

Basic blink example cannot be compiled without this patch.
